### PR TITLE
Look for version 17 of react and react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
   "pre-commit": "lint:staged",
   "dependencies": {},
   "peerDependencies": {
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react": "^16.8.6 || ^17",
+    "react-dom": "^16.8.6 || ^17"
   },
   "devDependencies": {
     "@babel/core": "^7.10.2",


### PR DESCRIPTION
Assuming this works with version 17 of react and react-dom. Getting warnings that v 16.8.6 is required.

npm WARN react-screentype-hook@1.0.17 requires a peer of react@^16.8.6 but none is installed. You must install peer dependencies yourself.
npm WARN react-screentype-hook@1.0.17 requires a peer of react-dom@^16.8.6 but none is installed. You must install peer dependencies yourself.